### PR TITLE
Feature/devosender timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ See next code examples:
 * [senderasync.go](./examples/senderasync.go) Example to send data to Devo relay-in house in _asynchronous_ mode
 * [senderfileasevent.go](./examples/senderfileasevent.go) Example to send content of a file as only one event to Devo relay-in house. Using `io.Copy` func
 * [sendercentralrelaywithbuilder.go](./examples/sendercentralrelaywithbuilder.go) Example to send data to Devo central relay but instantiating client using `ClientBuilder`
+* [sendercentralrelaytimeout.go](./examples/sendercentralrelaytimeout.go) Example to send data to Devo central relay that you can set TCP connection timeout based on `ClientBuilder` option
 
 ## devologtable
 

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -72,6 +72,8 @@ type ClientBuilder struct {
 	chainFileName             *string
 	tlsInsecureSkipVerify     bool
 	tlsRenegotiation          tls.RenegotiationSupport
+	tcpTimeout                time.Duration
+	tcpKeepAlive              time.Duration
 }
 
 // ClienBuilderDevoCentralRelay is the type used to set Devo central relay as entrypoint
@@ -187,6 +189,12 @@ func (dsb *ClientBuilder) Build() (*Client, error) {
 		tls:              TLSSetup,
 		entryPoint:       dsb.entrypoint,
 		asyncErrors:      make(map[string]error),
+		tcp: tcpConfig{
+			tcpDialer: &net.Dialer{
+				Timeout:   dsb.tcpTimeout,
+				KeepAlive: dsb.tcpKeepAlive,
+			},
+		},
 	}
 
 	err := result.makeConnection()

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -406,12 +406,7 @@ func (dsc *Client) makeConnection() error {
 	}
 
 	// Make connection BODY
-	dialer := dsc.tcp.tcpDialer
-	if dialer == nil {
-		dialer = &net.Dialer{}
-	}
-
-	tcpConn, err := dialer.Dial(u.Scheme, u.Host)
+	tcpConn, err := dsc.tcp.tcpDialer.Dial(u.Scheme, u.Host)
 	if err != nil {
 		return fmt.Errorf("Error when try to open TCP connection to scheme: %s, host: %s, error: %w", u.Scheme, u.Host, err)
 	}

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -215,22 +215,9 @@ func NewDevoSenderTLSFiles(entrypoint string, keyFileName string, certFileName s
 // NewDevoSender Create new DevoSender with clean comunication using ClientBuilder
 // entrypoint is the Devo entrypoint where send events with protocol://fqdn:port format. You can use DevoCentralRelayXX constants to easy assign these value
 func NewDevoSender(entrypoint string) (*Client, error) {
-
-	result := Client{
-		ReplaceSequences: make(map[string]string),
-		entryPoint:       entrypoint,
-		asyncErrors:      make(map[string]error),
-	}
-
-	err := result.makeConnection()
-	if err != nil {
-		return nil, fmt.Errorf("Error when create new DevoSender: %w", err)
-	}
-
-	// Intialize default values
-	result.init()
-
-	return &result, nil
+	return NewClientBuilder().
+		EntryPoint(entrypoint).
+		Build()
 }
 
 // SetSyslogHostName overwrite hostname send in raw Syslog payload

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -206,17 +206,13 @@ func NewDevoSenderTLS(entrypoint string, key []byte, cert []byte, chain []byte) 
 
 // NewDevoSenderTLSFiles is similar to NewDevoSenderTLS but loading different certificates from files
 func NewDevoSenderTLSFiles(entrypoint string, keyFileName string, certFileName string, chainFileName *string) (*Client, error) {
-	dataKey, dataCert, dataChain, err := loadTLSFiles(keyFileName, certFileName, chainFileName)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewDevoSenderTLS(entrypoint, dataKey, dataCert, dataChain)
+	return NewClientBuilder().
+		EntryPoint(entrypoint).
+		TLSFiles(keyFileName, certFileName, chainFileName).
+		Build()
 }
 
-// NewDevoSenderTLSWithConfig Create new DevoSender with TLS comunication and some TLS configuration parameters
-// entrypoint is the Devo entrypoint where send events with protocol://fqdn:port format. You can use DevoCentralRelayXX constants to easy assign these value
-// NewDevoSender Create new DevoSender with clean comunication
+// NewDevoSender Create new DevoSender with clean comunication using ClientBuilder
 // entrypoint is the Devo entrypoint where send events with protocol://fqdn:port format. You can use DevoCentralRelayXX constants to easy assign these value
 func NewDevoSender(entrypoint string) (*Client, error) {
 

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -214,64 +214,6 @@ func NewDevoSenderTLSFiles(entrypoint string, keyFileName string, certFileName s
 
 // NewDevoSenderTLSWithConfig Create new DevoSender with TLS comunication and some TLS configuration parameters
 // entrypoint is the Devo entrypoint where send events with protocol://fqdn:port format. You can use DevoCentralRelayXX constants to easy assign these value
-// key, cert and chain are the content of X.5809 Key, Certificate and Chain CA respectively. See https://docs.devo.com/confluence/ndt/domain-administration/security-credentials/x-509-certificates for more info
-// insecureSkipVerify is value asigned to tls.Config.InsecureSkipVerify tls property
-// renegotiation is value asigned to tls.Config.Renegotiation tls property
-func NewDevoSenderTLSWithConfig(entrypoint string, key []byte, cert []byte, chain []byte, insecureSkipVerify bool, renegotiation tls.RenegotiationSupport) (*Client, error) {
-
-	if len(key) == 0 {
-		return nil, fmt.Errorf("key param can not be empty")
-	}
-	if len(cert) == 0 {
-		return nil, fmt.Errorf("cert param can not be empty")
-	}
-
-	// tlsSetup
-	tlsSetup := &tlsSetup{
-		tlsConfig: &tls.Config{
-			InsecureSkipVerify: insecureSkipVerify,
-			Renegotiation:      renegotiation,
-		},
-	}
-
-	// Create pool with chain cert
-	pool := x509.NewCertPool()
-	if len(chain) > 0 {
-		ok := pool.AppendCertsFromPEM(chain)
-		if !ok {
-			return nil, fmt.Errorf("Could not parse chain certificate, content %s", string(chain))
-		}
-		tlsSetup.tlsConfig.RootCAs = pool
-	}
-
-	// Load key and certificate
-	crts, err := tls.X509KeyPair(cert, key)
-	if err != nil {
-		return nil, fmt.Errorf("Error when load key and cert: %w", err)
-	}
-	tlsSetup.tlsConfig.Certificates = []tls.Certificate{crts}
-	tlsSetup.tlsConfig.BuildNameToCertificate()
-
-	result := Client{
-		ReplaceSequences: make(map[string]string),
-		tls:              tlsSetup,
-		entryPoint:       entrypoint,
-		asyncErrors:      make(map[string]error),
-	}
-
-	// Create connection
-	err = result.makeConnection()
-	if err != nil {
-		return nil, fmt.Errorf("Error when create new DevoSender (TLS): %w", err)
-	}
-
-	// Intialize default values
-	result.init()
-
-	return &result, nil
-
-}
-
 // NewDevoSender Create new DevoSender with clean comunication
 // entrypoint is the Devo entrypoint where send events with protocol://fqdn:port format. You can use DevoCentralRelayXX constants to easy assign these value
 func NewDevoSender(entrypoint string) (*Client, error) {

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -32,6 +32,9 @@ type DevoSender interface {
 type tlsSetup struct {
 	tlsConfig *tls.Config
 }
+type tcpConfig struct {
+	tcpDialer *net.Dialer
+}
 
 // Client is the engine that can send data to Devo throug central (tls) or in-house (clean) realy
 type Client struct {
@@ -44,6 +47,7 @@ type Client struct {
 	waitGroup         sync.WaitGroup
 	asyncErrors       map[string]error
 	asyncErrorsMutext sync.Mutex
+	tcp               tcpConfig
 }
 
 const (

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -196,10 +196,12 @@ func (dsb *ClientBuilder) Build() (*Client, error) {
 	return &result, nil
 }
 
-// NewDevoSenderTLS  is an alias of NewDevoSenderTLSWithConfig(entrypoint, key, cert, chain, false, tls.RenegotiateNever)
+// NewDevoSenderTLS create TLS connection using ClientBuiler with minimal configuration
 func NewDevoSenderTLS(entrypoint string, key []byte, cert []byte, chain []byte) (*Client, error) {
-	// Set default tls options
-	return NewDevoSenderTLSWithConfig(entrypoint, key, cert, chain, false, tls.RenegotiateNever)
+	return NewClientBuilder().
+		EntryPoint(entrypoint).
+		TLSCerts(key, cert, chain).
+		Build()
 }
 
 // NewDevoSenderTLSFiles is similar to NewDevoSenderTLS but loading different certificates from files

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -131,11 +131,13 @@ func (dsb *ClientBuilder) DevoCentralEntryPoint(relay ClienBuilderDevoCentralRel
 	return dsb
 }
 
+//TCPTimeout allow to set Timeout value configured in net.Dialer
 func (dsb *ClientBuilder) TCPTimeout(t time.Duration) *ClientBuilder {
 	dsb.tcpTimeout = t
 	return dsb
 }
 
+//TCPKeepAlive allow to set KeepAlive value configured in net.Dialer
 func (dsb *ClientBuilder) TCPKeepAlive(t time.Duration) *ClientBuilder {
 	dsb.tcpKeepAlive = t
 	return dsb

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -131,6 +131,16 @@ func (dsb *ClientBuilder) DevoCentralEntryPoint(relay ClienBuilderDevoCentralRel
 	return dsb
 }
 
+func (dsb *ClientBuilder) TCPTimeout(t time.Duration) *ClientBuilder {
+	dsb.tcpTimeout = t
+	return dsb
+}
+
+func (dsb *ClientBuilder) TCPKeepAlive(t time.Duration) *ClientBuilder {
+	dsb.tcpKeepAlive = t
+	return dsb
+}
+
 // ParseDevoCentralEntrySite returns ClientBuilderDevoCentralRelay based on site code.
 // valid codes are 'US' and 'EU'
 func ParseDevoCentralEntrySite(s string) (ClienBuilderDevoCentralRelay, error) {

--- a/devosender/devosender_test.go
+++ b/devosender/devosender_test.go
@@ -66,6 +66,7 @@ func TestClient_makeConnection(t *testing.T) {
 		waitGroup         sync.WaitGroup
 		asyncErrors       map[string]error
 		asyncErrorsMutext sync.Mutex
+		tcp               tcpConfig
 	}
 	tests := []struct {
 		name    string
@@ -95,6 +96,9 @@ func TestClient_makeConnection(t *testing.T) {
 			"Error when create tls connection",
 			fields{
 				entryPoint: "tcp://doesnot.exist.12345678987654321.org:13003",
+				tcp: tcpConfig{
+					tcpDialer: &net.Dialer{},
+				},
 				tls: func() *tlsSetup {
 					t := tlsSetup{}
 
@@ -116,6 +120,7 @@ func TestClient_makeConnection(t *testing.T) {
 				waitGroup:         tt.fields.waitGroup,
 				asyncErrors:       tt.fields.asyncErrors,
 				asyncErrorsMutext: tt.fields.asyncErrorsMutext,
+				tcp:               tt.fields.tcp,
 			}
 			if err := dsc.makeConnection(); (err != nil) != tt.wantErr {
 				t.Errorf("Client.makeConnection() error = %v, wantErr %v", err, tt.wantErr)

--- a/examples/sendercentralrelaytimeout.go
+++ b/examples/sendercentralrelaytimeout.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/cyberluisda/devo-go/devosender"
+)
+
+const (
+	tag                     = "test.keep.free"
+	message                 = "this is message the message number #"
+	secondsWaitBtwnMessages = 1
+)
+
+func main() {
+
+	if len(os.Args) < 7 {
+		fmt.Println("usage:", os.Args[0], "keyFile certFile chainFile US|EU timeout #events")
+		fmt.Println()
+		fmt.Println("This command is an example of sending data to Central Devo Relay. See https://docs.devo.com/confluence/ndt/sending-data-to-devo for more info")
+		fmt.Println("keyFile certFile chainFile are the files required to stablish TLS connection and authenticate to your Devo domain. See https://docs.devo.com/confluence/ndt/domain-administration/security-credentials/x-509-certificates for more info")
+		fmt.Println("US|UE select the Devo site")
+		fmt.Println("timeout is the timeout parseable by time.ParseDuration")
+		fmt.Println("#events is the number of events that current program will send to Devo (one event per second)")
+		os.Exit(1)
+	}
+
+	numSeconds, err := strconv.Atoi(os.Args[6])
+	if err != nil {
+		log.Fatalf("Error when parse number of seconds while to send events (%s): %v\n", os.Args[6], err)
+	}
+
+	site, err := devosender.ParseDevoCentralEntrySite(os.Args[4])
+	if err != nil {
+		log.Fatalf("Site '%s' is not valid", os.Args[4])
+	}
+
+	dcb := devosender.NewClientBuilder()
+	sender, err := dcb.
+		DevoCentralEntryPoint(site).
+		TLSFiles(os.Args[1], os.Args[2], &os.Args[3]).
+		TCPTimeout(mustParseDuration(os.Args[5])).
+		Build()
+
+	if err != nil {
+		log.Fatalf("Error when intialize Devo Sender Client: %v\n", err)
+	}
+	defer sender.Close()
+
+	sender.SetDefaultTag(tag)
+
+	for i := 1; i <= numSeconds; i++ {
+		msg := fmt.Sprintf("%s: %s%d", time.Now(), message, i)
+
+		fmt.Println("Sending message number", i, "to", sender.GetEntryPoint(), ":", tag)
+		err := sender.Send(msg)
+		if err != nil {
+			log.Fatalf("Error when send message # %d to default tag: %v", i, err)
+		}
+
+		time.Sleep(time.Second)
+	}
+}
+
+func mustParseDuration(s string) time.Duration {
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}


### PR DESCRIPTION
* Allow set `Timeout` and `KeepAlive` TCP parameters when open connection in DevoSender
* DevoSender code restructured to use Builder when instantiate clients.