### PR TITLE
Devosender expose Async IDs

### DIFF
--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -434,6 +434,23 @@ func (dsc *Client) GetEntryPoint() string {
 	return dsc.entryPoint
 }
 
+// AsyncIds return asyncIds that are currently runnig
+func (dsc *Client) AsyncIds() []string {
+	dsc.asyncItemsMutext.Lock()
+
+	r := make([]string, len(dsc.asyncItems))
+
+	i := 0
+	for k := range dsc.asyncItems {
+		r[i] = k
+		i++
+	}
+
+	dsc.asyncItemsMutext.Unlock()
+
+	return r
+}
+
 // AddReplaceSequences is helper function to add elements to Client.ReplaceSequences
 // old is the string to search in message and new is the replacement string. Replacement will be done using strings.ReplaceAll
 func (dsc *Client) AddReplaceSequences(old, new string) error {

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -386,6 +386,11 @@ func (dsc *Client) SendWTagAsync(t, m string) string {
 
 	// Run Send with go routine (concurrent call)
 	go func(id string) {
+		// Save asyncItems ref ids
+		dsc.asyncItemsMutext.Lock()
+		dsc.asyncItems[id] = nil
+		dsc.asyncItemsMutext.Unlock()
+
 		err := dsc.SendWTag(t, m)
 		if err != nil {
 			dsc.asyncErrorsMutext.Lock()
@@ -394,6 +399,11 @@ func (dsc *Client) SendWTagAsync(t, m string) string {
 		}
 
 		dsc.waitGroup.Done()
+
+		// Remove id from asyncItems
+		dsc.asyncItemsMutext.Lock()
+		delete(dsc.asyncItems, id)
+		dsc.asyncItemsMutext.Unlock()
 	}(id)
 
 	return id

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -29,6 +29,7 @@ type DevoSender interface {
 	GetEntryPoint() string
 	AreAsyncOps() bool
 	AsyncIds() []string
+	IsAsyncActive() bool
 }
 
 type tlsSetup struct {

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -27,6 +27,8 @@ type DevoSender interface {
 	AsyncErrors() map[string]error
 	PurgeAsyncErrors()
 	GetEntryPoint() string
+	AreAsyncOps() bool
+	AsyncIds() []string
 }
 
 type tlsSetup struct {

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -453,7 +453,7 @@ func (dsc *Client) AsyncIds() []string {
 	return r
 }
 
-// AreAsyncOps return true is there is any Async operation running
+// AreAsyncOps returns true is there is any Async operation running
 func (dsc *Client) AreAsyncOps() bool {
 	dsc.asyncItemsMutext.Lock()
 
@@ -462,6 +462,18 @@ func (dsc *Client) AreAsyncOps() bool {
 	dsc.asyncItemsMutext.Unlock()
 
 	return r
+}
+
+// IsAsyncActive returns true if id is present in AsyncIds(). This function is
+// more optimal that look into result of AsyncIds
+func (dsc *Client) IsAsyncActive(id string) bool {
+	dsc.asyncItemsMutext.Lock()
+
+	_, ok := dsc.asyncItems[id]
+
+	dsc.asyncItemsMutext.Unlock()
+
+	return ok
 }
 
 // AddReplaceSequences is helper function to add elements to Client.ReplaceSequences

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -51,6 +51,8 @@ type Client struct {
 	connectionUsedTimestamp time.Time
 	connectionUsedTSMutext  sync.Mutex
 	maxTimeConnActive       time.Duration
+	asyncItems              map[string]interface{}
+	asyncItemsMutext        sync.Mutex
 }
 
 const (

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -451,6 +451,17 @@ func (dsc *Client) AsyncIds() []string {
 	return r
 }
 
+// AreAsyncOps return true is there is any Async operation running
+func (dsc *Client) AreAsyncOps() bool {
+	dsc.asyncItemsMutext.Lock()
+
+	r := len(dsc.asyncItems) > 0
+
+	dsc.asyncItemsMutext.Unlock()
+
+	return r
+}
+
 // AddReplaceSequences is helper function to add elements to Client.ReplaceSequences
 // old is the string to search in message and new is the replacement string. Replacement will be done using strings.ReplaceAll
 func (dsc *Client) AddReplaceSequences(old, new string) error {

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -23,7 +23,7 @@ type DevoSender interface {
 	SendWTag(t, m string) error
 	SendAsync(m string) string
 	SendWTagAsync(t, m string) string
-	WaitForPendingAsyngMessages() error
+	WaitForPendingAsyncMessages() error
 	AsyncErrors() map[string]error
 	PurgeAsyncErrors()
 	GetEntryPoint() string
@@ -411,8 +411,8 @@ func (dsc *Client) SendWTagAsync(t, m string) string {
 	return id
 }
 
-// WaitForPendingAsyngMessages wait for all Async messages that are pending to send
-func (dsc *Client) WaitForPendingAsyngMessages() error {
+// WaitForPendingAsyncMessages wait for all Async messages that are pending to send
+func (dsc *Client) WaitForPendingAsyncMessages() error {
 	dsc.waitGroup.Wait()
 	return nil
 }

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -220,6 +220,7 @@ func (dsb *ClientBuilder) Build() (*Client, error) {
 			},
 		},
 		maxTimeConnActive: dsb.connExpiration,
+		asyncItems:        make(map[string]interface{}),
 	}
 
 	err := result.makeConnection()

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -348,6 +348,11 @@ func (dsc *Client) SendAsync(m string) string {
 
 	// Run Send with go routine (concurrent call)
 	go func(id string) {
+		// Save asyncItems ref ids
+		dsc.asyncItemsMutext.Lock()
+		dsc.asyncItems[id] = nil
+		dsc.asyncItemsMutext.Unlock()
+
 		err := dsc.Send(m)
 		if err != nil {
 			dsc.asyncErrorsMutext.Lock()
@@ -356,6 +361,11 @@ func (dsc *Client) SendAsync(m string) string {
 		}
 
 		dsc.waitGroup.Done()
+
+		// Remove id from asyncItems
+		dsc.asyncItemsMutext.Lock()
+		delete(dsc.asyncItems, id)
+		dsc.asyncItemsMutext.Unlock()
 	}(id)
 
 	return id

--- a/devosender/devosender_test.go
+++ b/devosender/devosender_test.go
@@ -1655,3 +1655,77 @@ func TestClient_AsyncIds(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_AreAsyncOps(t *testing.T) {
+	type fields struct {
+		entryPoint              string
+		syslogHostname          string
+		defaultTag              string
+		conn                    net.Conn
+		ReplaceSequences        map[string]string
+		tls                     *tlsSetup
+		waitGroup               sync.WaitGroup
+		asyncErrors             map[string]error
+		asyncErrorsMutext       sync.Mutex
+		tcp                     tcpConfig
+		connectionUsedTimestamp time.Time
+		connectionUsedTSMutext  sync.Mutex
+		maxTimeConnActive       time.Duration
+		asyncItems              map[string]interface{}
+		asyncItemsMutext        sync.Mutex
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			"Empty input",
+			fields{},
+			false,
+		},
+		{
+			"Empty ids",
+			fields{
+				asyncItems: make(map[string]interface{}),
+			},
+			false,
+		},
+		{
+			"With ids",
+			fields{
+				asyncItems: map[string]interface{}{
+					"one":  nil,
+					"two":  "three",
+					"four": 5,
+				},
+			},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsc := &Client{
+				entryPoint:              tt.fields.entryPoint,
+				syslogHostname:          tt.fields.syslogHostname,
+				defaultTag:              tt.fields.defaultTag,
+				conn:                    tt.fields.conn,
+				ReplaceSequences:        tt.fields.ReplaceSequences,
+				tls:                     tt.fields.tls,
+				waitGroup:               tt.fields.waitGroup,
+				asyncErrors:             tt.fields.asyncErrors,
+				asyncErrorsMutext:       tt.fields.asyncErrorsMutext,
+				tcp:                     tt.fields.tcp,
+				connectionUsedTimestamp: tt.fields.connectionUsedTimestamp,
+				connectionUsedTSMutext:  tt.fields.connectionUsedTSMutext,
+				maxTimeConnActive:       tt.fields.maxTimeConnActive,
+				asyncItems:              tt.fields.asyncItems,
+				asyncItemsMutext:        tt.fields.asyncItemsMutext,
+			}
+			if got := dsc.AreAsyncOps(); got != tt.want {
+				t.Errorf("Client.AreAsyncOps() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/devosender/devosender_test.go
+++ b/devosender/devosender_test.go
@@ -68,6 +68,8 @@ func TestClient_makeConnection(t *testing.T) {
 		asyncErrors       map[string]error
 		asyncErrorsMutext sync.Mutex
 		tcp               tcpConfig
+		asyncItems        map[string]interface{}
+		asyncItemsMutext  sync.Mutex
 	}
 	tests := []struct {
 		name    string
@@ -122,6 +124,8 @@ func TestClient_makeConnection(t *testing.T) {
 				asyncErrors:       tt.fields.asyncErrors,
 				asyncErrorsMutext: tt.fields.asyncErrorsMutext,
 				tcp:               tt.fields.tcp,
+				asyncItems:        tt.fields.asyncItems,
+				asyncItemsMutext:  tt.fields.asyncItemsMutext,
 			}
 			if err := dsc.makeConnection(); (err != nil) != tt.wantErr {
 				t.Errorf("Client.makeConnection() error = %v, wantErr %v", err, tt.wantErr)
@@ -141,6 +145,8 @@ func TestClient_AddReplaceSequences(t *testing.T) {
 		waitGroup         sync.WaitGroup
 		asyncErrors       map[string]error
 		asyncErrorsMutext sync.Mutex
+		asyncItems        map[string]interface{}
+		asyncItemsMutext  sync.Mutex
 	}
 	type args struct {
 		old string
@@ -188,6 +194,8 @@ func TestClient_AddReplaceSequences(t *testing.T) {
 				waitGroup:         tt.fields.waitGroup,
 				asyncErrors:       tt.fields.asyncErrors,
 				asyncErrorsMutext: tt.fields.asyncErrorsMutext,
+				asyncItems:        tt.fields.asyncItems,
+				asyncItemsMutext:  tt.fields.asyncItemsMutext,
 			}
 			if err := dsc.AddReplaceSequences(tt.args.old, tt.args.new); (err != nil) != tt.wantErr {
 				t.Errorf("Client.AddReplaceSequences() error = %v, wantErr %v", err, tt.wantErr)
@@ -207,6 +215,8 @@ func TestClient_AsyncErrors(t *testing.T) {
 		waitGroup         sync.WaitGroup
 		asyncErrors       map[string]error
 		asyncErrorsMutext sync.Mutex
+		asyncItems        map[string]interface{}
+		asyncItemsMutext  sync.Mutex
 	}
 	tests := []struct {
 		name   string
@@ -233,6 +243,8 @@ func TestClient_AsyncErrors(t *testing.T) {
 				waitGroup:         tt.fields.waitGroup,
 				asyncErrors:       tt.fields.asyncErrors,
 				asyncErrorsMutext: tt.fields.asyncErrorsMutext,
+				asyncItems:        tt.fields.asyncItems,
+				asyncItemsMutext:  tt.fields.asyncItemsMutext,
 			}
 			if got := dsc.AsyncErrors(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Client.AsyncErrors() = %v, want %v", got, tt.want)
@@ -252,6 +264,8 @@ func TestClient_WaitForPendingAsyngMessages(t *testing.T) {
 		waitGroup         sync.WaitGroup
 		asyncErrors       map[string]error
 		asyncErrorsMutext sync.Mutex
+		asyncItems        map[string]interface{}
+		asyncItemsMutext  sync.Mutex
 	}
 	tests := []struct {
 		name    string
@@ -276,6 +290,8 @@ func TestClient_WaitForPendingAsyngMessages(t *testing.T) {
 				waitGroup:         tt.fields.waitGroup,
 				asyncErrors:       tt.fields.asyncErrors,
 				asyncErrorsMutext: tt.fields.asyncErrorsMutext,
+				asyncItems:        tt.fields.asyncItems,
+				asyncItemsMutext:  tt.fields.asyncItemsMutext,
 			}
 			if err := dsc.WaitForPendingAsyngMessages(); (err != nil) != tt.wantErr {
 				t.Errorf("Client.WaitForPendingAsyngMessages() error = %v, wantErr %v", err, tt.wantErr)
@@ -428,6 +444,8 @@ func TestClient_SetDefaultTag(t *testing.T) {
 		waitGroup         sync.WaitGroup
 		asyncErrors       map[string]error
 		asyncErrorsMutext sync.Mutex
+		asyncItems        map[string]interface{}
+		asyncItemsMutext  sync.Mutex
 	}
 	type args struct {
 		t string
@@ -468,6 +486,8 @@ func TestClient_SetDefaultTag(t *testing.T) {
 				waitGroup:         tt.fields.waitGroup,
 				asyncErrors:       tt.fields.asyncErrors,
 				asyncErrorsMutext: tt.fields.asyncErrorsMutext,
+				asyncItems:        tt.fields.asyncItems,
+				asyncItemsMutext:  tt.fields.asyncItemsMutext,
 			}
 			if err := dsc.SetDefaultTag(tt.args.t); (err != nil) != tt.wantErr {
 				t.Errorf("Client.SetDefaultTag() error = %v, wantErr %v", err, tt.wantErr)
@@ -490,6 +510,8 @@ func TestClient_SetSyslogHostName(t *testing.T) {
 		waitGroup         sync.WaitGroup
 		asyncErrors       map[string]error
 		asyncErrorsMutext sync.Mutex
+		asyncItems        map[string]interface{}
+		asyncItemsMutext  sync.Mutex
 	}
 	type args struct {
 		host string
@@ -528,6 +550,8 @@ func TestClient_SetSyslogHostName(t *testing.T) {
 				waitGroup:         tt.fields.waitGroup,
 				asyncErrors:       tt.fields.asyncErrors,
 				asyncErrorsMutext: tt.fields.asyncErrorsMutext,
+				asyncItems:        tt.fields.asyncItems,
+				asyncItemsMutext:  tt.fields.asyncItemsMutext,
 			}
 			dsc.SetSyslogHostName(tt.args.host)
 			if tt.wantSyslogHostname != dsc.syslogHostname {
@@ -622,6 +646,8 @@ func TestClient_PurgeAsyncErrors(t *testing.T) {
 		waitGroup         sync.WaitGroup
 		asyncErrors       map[string]error
 		asyncErrorsMutext sync.Mutex
+		asyncItems        map[string]interface{}
+		asyncItemsMutext  sync.Mutex
 	}
 	tests := []struct {
 		name   string
@@ -652,6 +678,8 @@ func TestClient_PurgeAsyncErrors(t *testing.T) {
 				waitGroup:         tt.fields.waitGroup,
 				asyncErrors:       tt.fields.asyncErrors,
 				asyncErrorsMutext: tt.fields.asyncErrorsMutext,
+				asyncItems:        tt.fields.asyncItems,
+				asyncItemsMutext:  tt.fields.asyncItemsMutext,
 			}
 			dsc.PurgeAsyncErrors()
 			if dsc.asyncErrors != nil && len(dsc.asyncErrors) > 0 {
@@ -672,6 +700,8 @@ func TestClient_GetEntryPoint(t *testing.T) {
 		waitGroup         sync.WaitGroup
 		asyncErrors       map[string]error
 		asyncErrorsMutext sync.Mutex
+		asyncItems        map[string]interface{}
+		asyncItemsMutext  sync.Mutex
 	}
 	tests := []struct {
 		name   string
@@ -698,6 +728,8 @@ func TestClient_GetEntryPoint(t *testing.T) {
 				waitGroup:         tt.fields.waitGroup,
 				asyncErrors:       tt.fields.asyncErrors,
 				asyncErrorsMutext: tt.fields.asyncErrorsMutext,
+				asyncItems:        tt.fields.asyncItems,
+				asyncItemsMutext:  tt.fields.asyncItemsMutext,
 			}
 			if got := dsc.GetEntryPoint(); got != tt.want {
 				t.Errorf("Client.GetEntryPoint() = %v, want %v", got, tt.want)

--- a/devosender/devosender_test.go
+++ b/devosender/devosender_test.go
@@ -254,7 +254,7 @@ func TestClient_AsyncErrors(t *testing.T) {
 	}
 }
 
-func TestClient_WaitForPendingAsyngMessages(t *testing.T) {
+func TestClient_WaitForPendingAsyncMessages(t *testing.T) {
 	type fields struct {
 		entryPoint        string
 		syslogHostname    string
@@ -294,8 +294,8 @@ func TestClient_WaitForPendingAsyngMessages(t *testing.T) {
 				asyncItems:        tt.fields.asyncItems,
 				asyncItemsMutext:  tt.fields.asyncItemsMutext,
 			}
-			if err := dsc.WaitForPendingAsyngMessages(); (err != nil) != tt.wantErr {
-				t.Errorf("Client.WaitForPendingAsyngMessages() error = %v, wantErr %v", err, tt.wantErr)
+			if err := dsc.WaitForPendingAsyncMessages(); (err != nil) != tt.wantErr {
+				t.Errorf("Client.WaitForPendingAsyncMessages() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/examples/senderasync.go
+++ b/examples/senderasync.go
@@ -71,7 +71,7 @@ func main() {
 	)
 
 	// Wait for messages sent and report errors if found
-	sender.WaitForPendingAsyngMessages()
+	sender.WaitForPendingAsyncMessages()
 
 	if len(sender.AsyncErrors()) > 0 {
 		fmt.Println("Errors inventory:")

--- a/examples/senderasync.go
+++ b/examples/senderasync.go
@@ -55,6 +55,8 @@ func main() {
 		idsCustomTag[i-1] = sender.SendWTagAsync(tag, fmt.Sprintf("%s%d", message, i))
 	}
 
+	fmt.Printf("Remaining ids (before wait): %v\n", sender.AsyncIds())
+
 	fmt.Printf("Id of messages sent with custom tag (%s):\n", defaultTag)
 	for _, id := range idsDefaultTag {
 		fmt.Println(id)
@@ -72,6 +74,8 @@ func main() {
 
 	// Wait for messages sent and report errors if found
 	sender.WaitForPendingAsyncMessages()
+
+	fmt.Printf("Remaining ids (after wait): %v\n", sender.AsyncIds())
 
 	if len(sender.AsyncErrors()) > 0 {
 		fmt.Println("Errors inventory:")


### PR DESCRIPTION
Until now only get errors of Async send events were exposed by DevoSender. Now you can acceess to ID of _Async send events_ that are currently working