### PR TITLE
Some improvements in devo logger

### DIFF
--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -30,6 +30,7 @@ type DevoSender interface {
 	AreAsyncOps() bool
 	AsyncIds() []string
 	IsAsyncActive() bool
+	AsyncsNumber() int
 }
 
 type tlsSetup struct {

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -549,6 +549,34 @@ func (dsc *Client) Close() error {
 	return dsc.conn.Close()
 }
 
+func (dsc *Client) String() string {
+	connAddr := "<nil>"
+	if dsc.conn != nil {
+		connAddr = fmt.Sprintf("%s -> %s", dsc.conn.LocalAddr(), dsc.conn.RemoteAddr())
+	}
+
+	dsc.connectionUsedTSMutext.Lock()
+	connUsedTimestamp := fmt.Sprintf("%v", dsc.connectionUsedTimestamp)
+	dsc.connectionUsedTSMutext.Unlock()
+
+	return fmt.Sprintf(
+		"entryPoint: '%s', syslogHostname: '%s', defaultTag: '%s', connAddr: '%s', "+
+			"ReplaceSequences: %v, tls: %v, #asyncErrors: %d, tcp: %v, connectionUsedTimestamp: '%s'"+
+			"maxTimeConnActive: '%v', #asyncItems: %d",
+		dsc.entryPoint,
+		dsc.syslogHostname,
+		dsc.defaultTag,
+		connAddr,
+		dsc.ReplaceSequences,
+		dsc.tls,
+		dsc.AsyncErrorsNumber(),
+		dsc.tcp,
+		connUsedTimestamp,
+		dsc.maxTimeConnActive,
+		dsc.AsyncsNumber(),
+	)
+}
+
 func (dsc *Client) makeConnection() error {
 	if dsc.entryPoint == "" {
 		return fmt.Errorf("Entrypoint can not be empty")

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -25,6 +25,7 @@ type DevoSender interface {
 	SendWTagAsync(t, m string) string
 	WaitForPendingAsyncMessages() error
 	AsyncErrors() map[string]error
+	AsyncErrorsNumber() int
 	PurgeAsyncErrors()
 	GetEntryPoint() string
 	AreAsyncOps() bool

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -32,6 +32,7 @@ type DevoSender interface {
 	AsyncIds() []string
 	IsAsyncActive() bool
 	AsyncsNumber() int
+	String() string
 }
 
 type tlsSetup struct {

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -419,7 +419,8 @@ func (dsc *Client) WaitForPendingAsyncMessages() error {
 	return nil
 }
 
-// AsyncErrors return errors from async calls collected until now
+// AsyncErrors return errors from async calls collected until now.
+// WARNING that map returned IS NOT thread safe.
 func (dsc *Client) AsyncErrors() map[string]error {
 	return dsc.asyncErrors
 }

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -428,9 +428,13 @@ func (dsc *Client) AsyncErrors() map[string]error {
 // PurgeAsyncErrors cleans internal AsyncErrors captured until now
 func (dsc *Client) PurgeAsyncErrors() {
 	if dsc.asyncErrors != nil {
+		dsc.asyncErrorsMutext.Lock()
+
 		for k := range dsc.asyncErrors {
 			delete(dsc.asyncErrors, k)
 		}
+
+		dsc.asyncErrorsMutext.Unlock()
 	}
 }
 

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -477,6 +477,17 @@ func (dsc *Client) IsAsyncActive(id string) bool {
 	return ok
 }
 
+// AsyncsNumber return the number of async operations pending. This is more optimal that call len(dsc.AsyncIds())
+func (dsc *Client) AsyncsNumber() int {
+	dsc.asyncItemsMutext.Lock()
+
+	r := len(dsc.asyncItems)
+
+	dsc.asyncItemsMutext.Unlock()
+
+	return r
+}
+
 // AddReplaceSequences is helper function to add elements to Client.ReplaceSequences
 // old is the string to search in message and new is the replacement string. Replacement will be done using strings.ReplaceAll
 func (dsc *Client) AddReplaceSequences(old, new string) error {

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -231,7 +231,11 @@ func (dsb *ClientBuilder) Build() (*Client, error) {
 
 	err := result.makeConnection()
 	if err != nil {
-		return nil, fmt.Errorf("Error when create new DevoSender (TLS): %w", err)
+		mode := "(Clear)"
+		if TLSSetup != nil {
+			mode = "(TLS)"
+		}
+		return nil, fmt.Errorf("Error when create new DevoSender %s: %w", mode, err)
 	}
 
 	// Intialize default values

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -562,7 +562,7 @@ func (dsc *Client) String() string {
 
 	return fmt.Sprintf(
 		"entryPoint: '%s', syslogHostname: '%s', defaultTag: '%s', connAddr: '%s', "+
-			"ReplaceSequences: %v, tls: %v, #asyncErrors: %d, tcp: %v, connectionUsedTimestamp: '%s'"+
+			"ReplaceSequences: %v, tls: %v, #asyncErrors: %d, tcp: %v, connectionUsedTimestamp: '%s', "+
 			"maxTimeConnActive: '%v', #asyncItems: %d",
 		dsc.entryPoint,
 		dsc.syslogHostname,

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -425,6 +425,17 @@ func (dsc *Client) AsyncErrors() map[string]error {
 	return dsc.asyncErrors
 }
 
+// AsyncErrorsNumber return then number of errors from async calls collected until now
+func (dsc *Client) AsyncErrorsNumber() int {
+	dsc.asyncErrorsMutext.Lock()
+
+	r := len(dsc.asyncErrors)
+
+	dsc.asyncErrorsMutext.Unlock()
+
+	return r
+}
+
 // PurgeAsyncErrors cleans internal AsyncErrors captured until now
 func (dsc *Client) PurgeAsyncErrors() {
 	if dsc.asyncErrors != nil {

--- a/devosender/devosender_test.go
+++ b/devosender/devosender_test.go
@@ -1827,3 +1827,70 @@ func TestClient_IsAsyncActive(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_AsyncsNumber(t *testing.T) {
+	type fields struct {
+		entryPoint              string
+		syslogHostname          string
+		defaultTag              string
+		conn                    net.Conn
+		ReplaceSequences        map[string]string
+		tls                     *tlsSetup
+		waitGroup               sync.WaitGroup
+		asyncErrors             map[string]error
+		asyncErrorsMutext       sync.Mutex
+		tcp                     tcpConfig
+		connectionUsedTimestamp time.Time
+		connectionUsedTSMutext  sync.Mutex
+		maxTimeConnActive       time.Duration
+		asyncItems              map[string]interface{}
+		asyncItemsMutext        sync.Mutex
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   int
+	}{
+		{
+			"Empty",
+			fields{},
+			0,
+		},
+		{
+			"With async ops",
+			fields{
+				asyncItems: map[string]interface{}{
+					"12345":  nil,
+					"55432":  nil,
+					"765454": nil,
+					"aba":    nil,
+				},
+			},
+			4,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsc := &Client{
+				entryPoint:              tt.fields.entryPoint,
+				syslogHostname:          tt.fields.syslogHostname,
+				defaultTag:              tt.fields.defaultTag,
+				conn:                    tt.fields.conn,
+				ReplaceSequences:        tt.fields.ReplaceSequences,
+				tls:                     tt.fields.tls,
+				waitGroup:               tt.fields.waitGroup,
+				asyncErrors:             tt.fields.asyncErrors,
+				asyncErrorsMutext:       tt.fields.asyncErrorsMutext,
+				tcp:                     tt.fields.tcp,
+				connectionUsedTimestamp: tt.fields.connectionUsedTimestamp,
+				connectionUsedTSMutext:  tt.fields.connectionUsedTSMutext,
+				maxTimeConnActive:       tt.fields.maxTimeConnActive,
+				asyncItems:              tt.fields.asyncItems,
+				asyncItemsMutext:        tt.fields.asyncItemsMutext,
+			}
+			if got := dsc.AsyncsNumber(); got != tt.want {
+				t.Errorf("Client.AsyncsNumber() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/devosender/devosender_test.go
+++ b/devosender/devosender_test.go
@@ -254,6 +254,45 @@ func TestClient_AsyncErrors(t *testing.T) {
 	}
 }
 
+func TestClient_AsyncErrorsNumber(t *testing.T) {
+	type fields struct {
+		asyncErrors       map[string]error
+		asyncErrorsMutext sync.Mutex
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   int
+	}{
+		{
+			"Empty",
+			fields{},
+			0,
+		},
+		{
+			"With errors",
+			fields{
+				asyncErrors: map[string]error{
+					"12324":    nil,
+					"asdfsadf": nil,
+				},
+			},
+			2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsc := &Client{
+				asyncErrors:       tt.fields.asyncErrors,
+				asyncErrorsMutext: tt.fields.asyncErrorsMutext,
+			}
+			if got := dsc.AsyncErrorsNumber(); got != tt.want {
+				t.Errorf("Client.AsyncErrorsNumber() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClient_WaitForPendingAsyncMessages(t *testing.T) {
 	type fields struct {
 		entryPoint        string

--- a/devosender/devosender_test.go
+++ b/devosender/devosender_test.go
@@ -1843,21 +1843,8 @@ func TestClient_IsAsyncActive(t *testing.T) {
 
 func TestClient_AsyncsNumber(t *testing.T) {
 	type fields struct {
-		entryPoint              string
-		syslogHostname          string
-		defaultTag              string
-		conn                    net.Conn
-		ReplaceSequences        map[string]string
-		tls                     *tlsSetup
-		waitGroup               sync.WaitGroup
-		asyncErrors             map[string]error
-		asyncErrorsMutext       sync.Mutex
-		tcp                     tcpConfig
-		connectionUsedTimestamp time.Time
-		connectionUsedTSMutext  sync.Mutex
-		maxTimeConnActive       time.Duration
-		asyncItems              map[string]interface{}
-		asyncItemsMutext        sync.Mutex
+		asyncItems       map[string]interface{}
+		asyncItemsMutext sync.Mutex
 	}
 	tests := []struct {
 		name   string
@@ -1885,21 +1872,8 @@ func TestClient_AsyncsNumber(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dsc := &Client{
-				entryPoint:              tt.fields.entryPoint,
-				syslogHostname:          tt.fields.syslogHostname,
-				defaultTag:              tt.fields.defaultTag,
-				conn:                    tt.fields.conn,
-				ReplaceSequences:        tt.fields.ReplaceSequences,
-				tls:                     tt.fields.tls,
-				waitGroup:               tt.fields.waitGroup,
-				asyncErrors:             tt.fields.asyncErrors,
-				asyncErrorsMutext:       tt.fields.asyncErrorsMutext,
-				tcp:                     tt.fields.tcp,
-				connectionUsedTimestamp: tt.fields.connectionUsedTimestamp,
-				connectionUsedTSMutext:  tt.fields.connectionUsedTSMutext,
-				maxTimeConnActive:       tt.fields.maxTimeConnActive,
-				asyncItems:              tt.fields.asyncItems,
-				asyncItemsMutext:        tt.fields.asyncItemsMutext,
+				asyncItems:       tt.fields.asyncItems,
+				asyncItemsMutext: tt.fields.asyncItemsMutext,
 			}
 			if got := dsc.AsyncsNumber(); got != tt.want {
 				t.Errorf("Client.AsyncsNumber() = %v, want %v", got, tt.want)

--- a/devosender/devosender_test.go
+++ b/devosender/devosender_test.go
@@ -1771,21 +1771,8 @@ func TestClient_AreAsyncOps(t *testing.T) {
 
 func TestClient_IsAsyncActive(t *testing.T) {
 	type fields struct {
-		entryPoint              string
-		syslogHostname          string
-		defaultTag              string
-		conn                    net.Conn
-		ReplaceSequences        map[string]string
-		tls                     *tlsSetup
-		waitGroup               sync.WaitGroup
-		asyncErrors             map[string]error
-		asyncErrorsMutext       sync.Mutex
-		tcp                     tcpConfig
-		connectionUsedTimestamp time.Time
-		connectionUsedTSMutext  sync.Mutex
-		maxTimeConnActive       time.Duration
-		asyncItems              map[string]interface{}
-		asyncItemsMutext        sync.Mutex
+		asyncItems       map[string]interface{}
+		asyncItemsMutext sync.Mutex
 	}
 	type args struct {
 		id string
@@ -1844,21 +1831,8 @@ func TestClient_IsAsyncActive(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dsc := &Client{
-				entryPoint:              tt.fields.entryPoint,
-				syslogHostname:          tt.fields.syslogHostname,
-				defaultTag:              tt.fields.defaultTag,
-				conn:                    tt.fields.conn,
-				ReplaceSequences:        tt.fields.ReplaceSequences,
-				tls:                     tt.fields.tls,
-				waitGroup:               tt.fields.waitGroup,
-				asyncErrors:             tt.fields.asyncErrors,
-				asyncErrorsMutext:       tt.fields.asyncErrorsMutext,
-				tcp:                     tt.fields.tcp,
-				connectionUsedTimestamp: tt.fields.connectionUsedTimestamp,
-				connectionUsedTSMutext:  tt.fields.connectionUsedTSMutext,
-				maxTimeConnActive:       tt.fields.maxTimeConnActive,
-				asyncItems:              tt.fields.asyncItems,
-				asyncItemsMutext:        tt.fields.asyncItemsMutext,
+				asyncItems:       tt.fields.asyncItems,
+				asyncItemsMutext: tt.fields.asyncItemsMutext,
 			}
 			if got := dsc.IsAsyncActive(tt.args.id); got != tt.want {
 				t.Errorf("Client.IsAsyncActive() = %v, want %v", got, tt.want)


### PR DESCRIPTION
* Some typos fixed
* New received func for `*Client`:
  * `AsyncErrorsNumber`
  * `AsyncsNumber`
  * `String`
* New funcs defined in `DevoSender` interface
  * `AsyncErrorsNumber`
  * `AsyncsNumber`
  * `String`
* Thread safe fixed in some funcs  