### PR TITLE
LastSendCallTimestamp added to SwitchDevoSender interface

### DIFF
--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -691,6 +691,7 @@ func (dsc *Client) AsyncsNumber() int {
 }
 
 // LastSendCallTimestamp returns the timestamp of last time that any of SendXXXX func was called with valid parameters
+// If Client is nil default time.Time value will be returned
 func (dsc *Client) LastSendCallTimestamp() time.Time {
 	if dsc == nil {
 		return time.Time{}

--- a/devosender/devosender_lazy.go
+++ b/devosender/devosender_lazy.go
@@ -33,6 +33,7 @@ type SwitchDevoSender interface {
 	StandBy() error
 	WakeUp() error
 	IsStandBy() bool
+	LastSendCallTimestamp() time.Time
 }
 
 // LazyClientBuilder is the builder to build LazyClient

--- a/devosender/devosender_reliable.go
+++ b/devosender/devosender_reliable.go
@@ -831,7 +831,10 @@ func (dsrc *ReliableClient) clientReconnectionDaemon() error {
 					dsrc.Client, err = dsrc.clientBuilder.Build()
 					// we can continue in connection error scenario
 					if err != nil {
-						// FIXME log
+						dsrc.appLogger.Logf(
+							applogger.ERROR,
+							"Error While create new client in Reconnection daemon: %v", err,
+						)
 					}
 				}
 			}

--- a/devosender/devosender_reliable_test.go
+++ b/devosender/devosender_reliable_test.go
@@ -844,8 +844,6 @@ func TestReliableClient_Close(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		// panic("TODO me llego aki")
-
 		t.Run(tt.name, func(t *testing.T) {
 			dsrc := &ReliableClient{
 				Client:                   tt.fields.Client,

--- a/devosender/example_devosender_lazy_test.go
+++ b/devosender/example_devosender_lazy_test.go
@@ -163,6 +163,7 @@ func ExampleLazyClient() {
 	}
 	fmt.Println("Stats (after WakeUp)", lc.Stats)
 	fmt.Println("LazyClient (after WakeUp)", lc.String()[0:146])
+	fmt.Println("SwitchDevoSender.LastSendCallTimestamp (after WakeUp) is empty", lc.LastSendCallTimestamp() == time.Time{})
 
 	var sender SwitchDevoSender
 	sender = lc
@@ -173,6 +174,7 @@ func ExampleLazyClient() {
 	fmt.Printf("ID has non-conn- prefix: %v\n", strings.HasPrefix(id, "non-conn-"))
 	fmt.Println("SwitchDevoSender (pending events after close)", sender.String())
 	fmt.Println("Stats (pending events after close)", lc.Stats)
+	fmt.Println("SwitchDevoSender.LastSendCallTimestamp (pending events after close) is empty", lc.LastSendCallTimestamp() == time.Time{})
 	sender.Close()
 	fmt.Println("SwitchDevoSender (after last close)", sender.String())
 	fmt.Println("Stats (after last close)", lc.Stats)
@@ -191,10 +193,12 @@ func ExampleLazyClient() {
 	// Stats AsyncEvents: 9, TotalBuffered: 0, BufferedLost: 0, SendFromBuffer: 0
 	// Stats (after WakeUp) AsyncEvents: 9, TotalBuffered: 0, BufferedLost: 0, SendFromBuffer: 0
 	// LazyClient (after WakeUp) bufferSize: 256000, standByMode: false, #eventsInBuffer: 0, flushTimeout: 2s, standByModeTimeout: 0s, Client: {entryPoint: 'udp://localhost:13000'
+	// SwitchDevoSender.LastSendCallTimestamp (after WakeUp) is empty false
 	// LazyClient as SwitchDevoSender closed bufferSize: 256000, standByMode: true, #eventsInBuffer: 0, flushTimeout: 2s, standByModeTimeout: 0s, Client: {<nil>}
 	// ID has non-conn- prefix: true
 	// SwitchDevoSender (pending events after close) bufferSize: 256000, standByMode: true, #eventsInBuffer: 1, flushTimeout: 2s, standByModeTimeout: 0s, Client: {<nil>}
 	// Stats (pending events after close) AsyncEvents: 10, TotalBuffered: 1, BufferedLost: 0, SendFromBuffer: 0
+	// SwitchDevoSender.LastSendCallTimestamp (pending events after close) is empty true
 	// SwitchDevoSender (after last close) bufferSize: 256000, standByMode: true, #eventsInBuffer: 0, flushTimeout: 2s, standByModeTimeout: 0s, Client: {<nil>}
 	// Stats (after last close) AsyncEvents: 10, TotalBuffered: 1, BufferedLost: 0, SendFromBuffer: 1
 }


### PR DESCRIPTION
Now implementations of `SwitchDevoSender` must implement `LastSendCallTimestamp() time.Time` function. This can be useful, for example, when you like to activate stand by mode in `SwitchDevoSender` but only if a certain period was passed after last event was send.