### PR TITLE
FlushTimeout in ReliableClientBuilder and LazyClientBuilder applies only with values > 0

### DIFF
--- a/devosender/devosender_lazy.go
+++ b/devosender/devosender_lazy.go
@@ -87,7 +87,7 @@ func (lcb *LazyClientBuilder) EnableStandByModeTimeout(d time.Duration) *LazyCli
 // FlushTimeout sets the timeout when wait for pending async envents in client when
 // Flush() func is called. Timeout is set only if parameter is greater than 0
 func (lcb *LazyClientBuilder) FlushTimeout(d time.Duration) *LazyClientBuilder {
-	if d >= 0 {
+	if d > 0 {
 		lcb.flushTimeout = d
 	}
 	return lcb

--- a/devosender/devosender_reliable.go
+++ b/devosender/devosender_reliable.go
@@ -159,7 +159,7 @@ func (dsrcb *ReliableClientBuilder) EnableStandByModeTimeout(d time.Duration) *R
 // FlushTimeout sets the timeout when wait for pending async envents in clien when
 // Flush() func is called
 func (dsrcb *ReliableClientBuilder) FlushTimeout(d time.Duration) *ReliableClientBuilder {
-	if d >= 0 {
+	if d > 0 {
 		dsrcb.flushTimeout = d
 	}
 

--- a/devosender/devosender_reliable_test.go
+++ b/devosender/devosender_reliable_test.go
@@ -273,7 +273,7 @@ func TestReliableClientBuilder_FlushTimeout(t *testing.T) {
 			},
 			args{0 * time.Millisecond},
 			&ReliableClientBuilder{
-				flushTimeout: 0,
+				flushTimeout: time.Hour,
 			},
 		},
 		{


### PR DESCRIPTION
This prevents situations like call create client with
```
c :=  LazyClientBuilder().FlushTimeout(0).Build()
```
 and then get errors when call 
```
c.WakeUp()
// or
c.Close()
```