### PR TITLE
Fix bug #28

### DIFF
--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -251,9 +251,10 @@ func (dsb *ClientBuilder) Build() (*Client, error) {
 				KeepAlive: dsb.tcpKeepAlive,
 			},
 		},
-		maxTimeConnActive: dsb.connExpiration,
-		asyncItems:        make(map[string]interface{}),
-		defaultTag:        dsb.defaultDevoTag,
+		maxTimeConnActive:    dsb.connExpiration,
+		asyncItems:           make(map[string]interface{}),
+		defaultTag:           dsb.defaultDevoTag,
+		isConnWorkingPayload: []byte(dsb.isConnWorkingCheckPayload),
 	}
 
 	err := result.makeConnection()

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -175,6 +175,18 @@ func (dsb *ClientBuilder) DefaultDevoTag(t string) *ClientBuilder {
 	return dsb
 }
 
+// IsConnWorkingCheckPayload sets the payload of the raw message that will be sent (Write) to check conection
+// during IsConnWorking call
+// Empty string implies that IsConnWorking will return an error. The payload size must be less that 4 characters
+func (dsb *ClientBuilder) IsConnWorkingCheckPayload(s string) *ClientBuilder {
+	if s == "" {
+		dsb.isConnWorkingCheckPayload = s
+	} else if len(s) < 4 {
+		dsb.isConnWorkingCheckPayload = s
+	}
+	return dsb
+}
+
 // ParseDevoCentralEntrySite returns ClientBuilderDevoCentralRelay based on site code.
 // valid codes are 'US' and 'EU'
 func ParseDevoCentralEntrySite(s string) (ClienBuilderDevoCentralRelay, error) {

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -771,7 +771,12 @@ func (dsc *Client) Close() error {
 	return dsc.conn.Close()
 }
 
+// ErrPayloadNoDefined is the error returned when payload is required by was not defined
+var ErrPayloadNoDefined = errors.New("Payload to check connection is not defined")
+
 // IsConnWorking check if connection is opened and make a test writing data to ensure that is working
+// If payload to check is not defined (ClientBuilder.IsConnWorkingCheckPayload) then ErrPayloadNoDefined
+// will be returned
 func (dsc *Client) IsConnWorking() (bool, error) {
 
 	if dsc == nil {
@@ -783,7 +788,7 @@ func (dsc *Client) IsConnWorking() (bool, error) {
 	}
 
 	if len(dsc.isConnWorkingPayload) == 0 {
-		return false, fmt.Errorf("Payload to check connection is not defined")
+		return false, ErrPayloadNoDefined
 	}
 
 	n, err := dsc.conn.Write(dsc.isConnWorkingPayload)

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -757,6 +757,30 @@ func (dsc *Client) Close() error {
 	return dsc.conn.Close()
 }
 
+// IsConnWorking check if connection is opened and make a test writing data to ensure that is working
+func (dsc *Client) IsConnWorking() (bool, error) {
+
+	if dsc == nil {
+		return false, nil
+	}
+
+	if dsc.conn == nil {
+		return false, nil
+	}
+
+	if len(dsc.isConnWorkingPayload) == 0 {
+		return false, fmt.Errorf("Payload to check connection is not defined")
+	}
+
+	n, err := dsc.conn.Write(dsc.isConnWorkingPayload)
+	if err == nil {
+		// Double check to be sure
+		n, err = dsc.conn.Write(dsc.isConnWorkingPayload)
+	}
+
+	return n != 0 && err == nil, nil
+}
+
 func (dsc *Client) String() string {
 	if dsc == nil {
 		return "<nil>"

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -178,6 +178,7 @@ func (dsb *ClientBuilder) DefaultDevoTag(t string) *ClientBuilder {
 // IsConnWorkingCheckPayload sets the payload of the raw message that will be sent (Write) to check conection
 // during IsConnWorking call
 // Empty string implies that IsConnWorking will return an error. The payload size must be less that 4 characters
+// Recommended value for this payload when you like to enable this check is zero-character: "\x00"
 func (dsb *ClientBuilder) IsConnWorkingCheckPayload(s string) *ClientBuilder {
 	if s == "" {
 		dsb.isConnWorkingCheckPayload = s

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -321,6 +321,7 @@ type Client struct {
 	lastSendCallTimestamp   time.Time
 	statsMutex              sync.Mutex
 	compressor              *Compressor
+	isConnWorkingPayload    []byte
 }
 
 type tlsSetup struct {

--- a/devosender/devosender.go
+++ b/devosender/devosender.go
@@ -80,6 +80,7 @@ type ClientBuilder struct {
 	compressorAlgorithm       CompressorAlgorithm
 	compressorMinSize         int
 	defaultDevoTag            string
+	isConnWorkingCheckPayload string
 }
 
 // ClienBuilderDevoCentralRelay is the type used to set Devo central relay as entrypoint

--- a/devosender/devosender_lazy_test.go
+++ b/devosender/devosender_lazy_test.go
@@ -243,6 +243,73 @@ func TestLazyClient_Wakeup_Close_unblocked(t *testing.T) {
 	}
 }
 
+func TestLazyClient_SendWTagAndCompressorAsync__server_restarted(t *testing.T) {
+
+	// Open new server
+	tcm := &tcpMockRelay{} // Implemented in devosender_reliable.go
+	err := tcm.Start()
+	if err != nil {
+		t.Errorf("Error while start mock relay server: %v", err)
+		return
+	}
+
+	// Create client
+	c, err := NewLazyClientBuilder().
+		ClientBuilder(
+			NewClientBuilder().
+				EntryPoint(fmt.Sprintf("tcp://localhost:%d", tcm.Port)).
+				IsConnWorkingCheckPayload("\n")).
+		Build()
+	if err != nil {
+		t.FailNow()
+	}
+
+	// Check that connetion is working
+	ok, _ := c.IsConnWorking()
+	if !ok {
+		t.Error("LazyClient.IsConnWorking() with server started, want true, got false")
+		t.FailNow()
+	}
+
+	// Waiting for tcm register connections
+	time.Sleep(time.Millisecond * 100)
+
+	// Stop the server
+	err = tcm.Stop()
+	if err != nil {
+		t.Errorf("Error while stop mock relay server: %v", err)
+		t.FailNow()
+	}
+
+	// Wait for connection is marked as "no working" or timeout
+	tries := 3
+	for ok, _ := c.IsConnWorking(); ok; ok, _ = c.IsConnWorking() { // we are sure that IsConnWorking does not return error
+		tries--
+		if tries == 0 {
+			t.Error("Timeout reached while wait for IsConnWorking return false")
+			t.FailNow()
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	// Start the server
+	err = tcm.Start()
+	if err != nil {
+		t.Errorf("Error while start again mock relay server: %v", err)
+		t.FailNow()
+	}
+
+	// Send new event
+	c.SendWTagAndCompressorAsync("test.keep.free", "msg", nil)
+	// Checks that connetion is working (recreated while sending event)
+	ok, _ = c.IsConnWorking()
+	if !ok {
+		t.Error("LazyClient.IsConnWorking() with server re-started after send event, want true, got false")
+	}
+
+	c.Close()
+}
+
 func TestLazyClient_popBuffer(t *testing.T) {
 	type fields struct {
 		buffer []*lazyClientRecord

--- a/devosender/devosender_reliable.go
+++ b/devosender/devosender_reliable.go
@@ -206,6 +206,7 @@ func (dsrcb *ReliableClientBuilder) Build() (*ReliableClient, error) {
 		retryWait:                dsrcb.retryDaemonOpts.waitBtwChecks,
 		retryInitDelay:           dsrcb.retryDaemonOpts.initDelay,
 		reconnWait:               dsrcb.clientReconnOpts.waitBtwChecks,
+		reconnInitDelay:          dsrcb.clientReconnOpts.initDelay,
 		daemonStopTimeout:        dsrcb.daemonStopTimeout,
 		daemonStopped:            make(chan bool),
 		flushTimeout:             dsrcb.flushTimeout,

--- a/devosender/devosender_reliable.go
+++ b/devosender/devosender_reliable.go
@@ -204,6 +204,7 @@ func (dsrcb *ReliableClientBuilder) Build() (*ReliableClient, error) {
 		bufferSize:               dsrcb.bufferEventsSize,
 		eventTTLSeconds:          dsrcb.eventTimeToLive,
 		retryWait:                dsrcb.retryDaemonOpts.waitBtwChecks,
+		retryInitDelay:           dsrcb.retryDaemonOpts.initDelay,
 		reconnWait:               dsrcb.clientReconnOpts.waitBtwChecks,
 		daemonStopTimeout:        dsrcb.daemonStopTimeout,
 		daemonStopped:            make(chan bool),

--- a/devosender/devosender_reliable.go
+++ b/devosender/devosender_reliable.go
@@ -836,9 +836,15 @@ func (dsrc *ReliableClient) clientReconnectionDaemon() error {
 		for !dsrc.reconnStop {
 			dsrc.clientMtx.Lock()
 			if !dsrc.IsStandBy() {
-				// TODO implement other heltcheck mechanism here
+				recreate := false
 				if dsrc.Client == nil {
-					// Build inner Client
+					recreate = true
+				} else if ok, err := dsrc.Client.IsConnWorking(); err != ErrPayloadNoDefined && !ok {
+					recreate = true
+				}
+
+				// Build inner Client
+				if recreate {
 					var err error
 					dsrc.Client, err = dsrc.clientBuilder.Build()
 					// we can continue in connection error scenario

--- a/devosender/devosender_reliable.go
+++ b/devosender/devosender_reliable.go
@@ -492,7 +492,7 @@ func (dsrc *ReliableClient) StandBy() error {
 			dsrc.standByMode = true
 			return fmt.Errorf("Error when close client passing to StandBy: %w", err)
 		}
-		// Destroy curret client to ensrue will be recreated when WakeUp
+		// Destroy curret client to ensure it will be recreated when WakeUp
 		dsrc.Client = nil
 	}
 

--- a/devosender/devosender_reliable.go
+++ b/devosender/devosender_reliable.go
@@ -831,7 +831,7 @@ func (dsrc *ReliableClient) clientReconnectionDaemon() error {
 	}
 	go func() {
 		// Init delay
-		time.Sleep(dsrc.retryInitDelay)
+		time.Sleep(dsrc.reconnInitDelay)
 
 		for !dsrc.reconnStop {
 			dsrc.clientMtx.Lock()

--- a/devosender/devosender_reliable.go
+++ b/devosender/devosender_reliable.go
@@ -526,6 +526,16 @@ func (dsrc *ReliableClient) IsStandBy() bool {
 	return dsrc.standByMode
 }
 
+// IsConnWorking is the same as Client.IsConnWorking but check first if client is in
+// stand by mode
+func (dsrc *ReliableClient) IsConnWorking() (bool, error) {
+	if dsrc.IsStandBy() {
+		return false, nil
+	}
+
+	return dsrc.Client.IsConnWorking()
+}
+
 // ReliableClientStats represents the stats that can be queried
 type ReliableClientStats struct {
 	Count    int

--- a/devosender/devosender_test.go
+++ b/devosender/devosender_test.go
@@ -1861,6 +1861,56 @@ func TestClientBuilder_DefaultDevoTag(t *testing.T) {
 	}
 }
 
+func TestClientBuilder_IsConnWorkingCheckPayload(t *testing.T) {
+	type fields struct {
+		isConnWorkingCheckPayload string
+	}
+	type args struct {
+		s string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   *ClientBuilder
+	}{
+		{
+			"Empty",
+			fields{"old"},
+			args{""},
+			&ClientBuilder{
+				isConnWorkingCheckPayload: "",
+			},
+		},
+		{
+			"Overlength value",
+			fields{"old"},
+			args{"lengt is greater than 4"},
+			&ClientBuilder{
+				isConnWorkingCheckPayload: "old",
+			},
+		},
+		{
+			"Valid value",
+			fields{""},
+			args{"\n"},
+			&ClientBuilder{
+				isConnWorkingCheckPayload: "\n",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsb := &ClientBuilder{
+				isConnWorkingCheckPayload: tt.fields.isConnWorkingCheckPayload,
+			}
+			if got := dsb.IsConnWorkingCheckPayload(tt.args.s); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ClientBuilder.IsConnWorkingCheckPayload() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseDevoCentralEntrySite(t *testing.T) {
 	type args struct {
 		s string

--- a/devosender/devosender_test.go
+++ b/devosender/devosender_test.go
@@ -1968,21 +1968,22 @@ func TestParseDevoCentralEntrySite(t *testing.T) {
 
 func TestClientBuilder_Build(t *testing.T) {
 	type fields struct {
-		entrypoint            string
-		key                   []byte
-		cert                  []byte
-		chain                 []byte
-		keyFileName           string
-		certFileName          string
-		chainFileName         *string
-		tlsInsecureSkipVerify bool
-		tlsRenegotiation      tls.RenegotiationSupport
-		tcpTimeout            time.Duration
-		tcpKeepAlive          time.Duration
-		connExpiration        time.Duration
-		compressorAlgorithm   CompressorAlgorithm
-		compressorMinSize     int
-		defaultDevoTag        string
+		entrypoint                string
+		key                       []byte
+		cert                      []byte
+		chain                     []byte
+		keyFileName               string
+		certFileName              string
+		chainFileName             *string
+		tlsInsecureSkipVerify     bool
+		tlsRenegotiation          tls.RenegotiationSupport
+		tcpTimeout                time.Duration
+		tcpKeepAlive              time.Duration
+		connExpiration            time.Duration
+		compressorAlgorithm       CompressorAlgorithm
+		compressorMinSize         int
+		defaultDevoTag            string
+		isConnWorkingCheckPayload string
 	}
 	tests := []struct {
 		name    string
@@ -2095,25 +2096,41 @@ func TestClientBuilder_Build(t *testing.T) {
 			}(),
 			false,
 		},
+		{
+			"With isConnWorkingCheckPayload",
+			fields{
+				entrypoint:                "udp://localhost:13000",
+				isConnWorkingCheckPayload: "\n",
+			},
+			func() *Client {
+				r, _ := NewDevoSender("udp://localhost:13000")
+				c := r.(*Client)
+				c.isConnWorkingPayload = []byte("\n")
+
+				return r.(*Client)
+			}(),
+			false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			dsb := &ClientBuilder{
-				entrypoint:            tt.fields.entrypoint,
-				key:                   tt.fields.key,
-				cert:                  tt.fields.cert,
-				chain:                 tt.fields.chain,
-				keyFileName:           tt.fields.keyFileName,
-				certFileName:          tt.fields.certFileName,
-				chainFileName:         tt.fields.chainFileName,
-				tlsInsecureSkipVerify: tt.fields.tlsInsecureSkipVerify,
-				tlsRenegotiation:      tt.fields.tlsRenegotiation,
-				tcpTimeout:            tt.fields.tcpTimeout,
-				tcpKeepAlive:          tt.fields.tcpKeepAlive,
-				connExpiration:        tt.fields.connExpiration,
-				compressorAlgorithm:   tt.fields.compressorAlgorithm,
-				compressorMinSize:     tt.fields.compressorMinSize,
-				defaultDevoTag:        tt.fields.defaultDevoTag,
+				entrypoint:                tt.fields.entrypoint,
+				key:                       tt.fields.key,
+				cert:                      tt.fields.cert,
+				chain:                     tt.fields.chain,
+				keyFileName:               tt.fields.keyFileName,
+				certFileName:              tt.fields.certFileName,
+				chainFileName:             tt.fields.chainFileName,
+				tlsInsecureSkipVerify:     tt.fields.tlsInsecureSkipVerify,
+				tlsRenegotiation:          tt.fields.tlsRenegotiation,
+				tcpTimeout:                tt.fields.tcpTimeout,
+				tcpKeepAlive:              tt.fields.tcpKeepAlive,
+				connExpiration:            tt.fields.connExpiration,
+				compressorAlgorithm:       tt.fields.compressorAlgorithm,
+				compressorMinSize:         tt.fields.compressorMinSize,
+				defaultDevoTag:            tt.fields.defaultDevoTag,
+				isConnWorkingCheckPayload: tt.fields.isConnWorkingCheckPayload,
 			}
 			got, err := dsb.Build()
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
* `IsConnWorking`: New method to check connection using Write([]byte) added to Client. Extended in `ReliableClient` having _stand by mode_ in mind
* Daemon to reconnect implemented in `ReliableClient` uses `IsConnWorking` to check if connection should be recreated.
* `LazyClient.XXXAsync`call `IsConnWorking` for each event to check if connetion/client must be restarted/recreated.